### PR TITLE
linux: Parse desktop files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "freedesktop_entry_parser"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9c27b72f19a99a895f8ca89e2d26e4ef31013376e56fdafef697627306c3e4"
+dependencies = [
+ "nom",
+ "thiserror",
+]
+
+[[package]]
 name = "freetype"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +3909,7 @@ dependencies = [
  "catppuccin",
  "dark-light",
  "env_logger",
+ "freedesktop_entry_parser",
  "futures",
  "global-hotkey",
  "gpui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ image = "0.23"
 [target.'cfg(target_os = "macos")'.dependencies]
 swift-rs = "1.0.6"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+freedesktop_entry_parser = "1.3.0"
 
 [features]
 tailscale = []

--- a/src/platform/linux/desktop_file.rs
+++ b/src/platform/linux/desktop_file.rs
@@ -1,0 +1,52 @@
+use std::path::PathBuf;
+use freedesktop_entry_parser::{AttrSelector, parse_entry};
+
+pub(crate) struct ApplicationDesktopFile {
+    pub name: String,
+    pub icon: Option<String>,
+    pub keywords: Vec<String>
+}
+
+pub(crate) enum DesktopFileError {
+    FileNotFound,
+    NoDesktopEntry,
+    InvalidFormat,
+    HiddenFile,
+}
+
+impl TryFrom<&PathBuf> for ApplicationDesktopFile {
+    type Error = DesktopFileError;
+
+    fn try_from(value: &PathBuf) -> Result<Self, Self::Error> {
+        let entry = parse_entry(value)
+            .map_err(|_| DesktopFileError::InvalidFormat)?;
+
+        let content_section: AttrSelector<&str> = entry.section("Desktop Entry");
+        let name = content_section.attr("Name")
+            .ok_or(DesktopFileError::NoDesktopEntry)?
+            .to_string();
+
+        let icon = content_section.attr("Icon")
+            .map(|s| s.to_string());
+
+        let keywords = content_section.attr("Keywords")
+            .map(|s| s.split(';').map(|s| s.to_string()).collect())
+            .unwrap_or_default();
+
+        let no_display = content_section.attr("NoDisplay")
+            .map_or(Ok(false), |s| s.parse::<bool>())
+            .map_err(|_| DesktopFileError::InvalidFormat)?;
+
+        if no_display {
+            // Hidden files are typically used for window managers and other system utilities
+            // so this is not an application we can start
+            return Err(DesktopFileError::HiddenFile);
+        }
+
+        Ok(ApplicationDesktopFile {
+            name,
+            icon,
+            keywords
+        })
+    }
+}

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,3 +1,5 @@
+mod desktop_file;
+
 use crate::components::shared::{Icon, Img};
 use crate::paths::paths;
 
@@ -12,7 +14,7 @@ pub fn get_app_data(path: &PathBuf) -> Option<AppData> {
         fs::create_dir_all(cache_dir.clone()).unwrap();
     }
     let cache = cache_dir.to_string_lossy().to_string();
-    let name = path
+    let file_name = path
         .components()
         .last()
         .unwrap()
@@ -20,12 +22,14 @@ pub fn get_app_data(path: &PathBuf) -> Option<AppData> {
         .to_string_lossy()
         .to_string();
 
+    let file = desktop_file::ApplicationDesktopFile::try_from(path).ok()?;
+
     Some(AppData {
-        id: name.clone(),
-        name: name.clone(),
+        id: file_name.clone(),
+        name: file.name.clone(),
         icon: Img::list_icon(Icon::AppWindow, None),
         icon_path: PathBuf::new(),
-        keywords: vec![],
+        keywords: file.keywords,
         tag: "Application".to_string(),
     })
 }


### PR DESCRIPTION
(See #18)

This PR tries to parse desktop files and show the actual names instead of the desktop file name.
I'll add icons in a future PR!

Again, awesome project. I'm really looking forward to using this as my primary app launcher!

![image](https://github.com/MatthiasGrandl/Loungy/assets/37768199/367d22c8-0cfd-40d3-81cc-061feaf6d13c)
