### PR TITLE
linux: png app icons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_panic"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,7 +1889,7 @@ dependencies = [
  "detect-desktop-environment",
  "dirs 4.0.0",
  "objc",
- "rust-ini",
+ "rust-ini 0.18.0",
  "web-sys",
  "winreg 0.10.1",
  "zbus 3.15.1",
@@ -2191,6 +2211,15 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
 
 [[package]]
 name = "downcast-rs"
@@ -2745,6 +2774,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "freedesktop-icons"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ef34245e0540c9a3ce7a28340b98d2c12b75da0d446da4e8224923fcaa0c16"
+dependencies = [
+ "dirs 5.0.1",
+ "once_cell",
+ "rust-ini 0.20.0",
+ "thiserror",
+ "xdg",
 ]
 
 [[package]]
@@ -3995,6 +4037,7 @@ dependencies = [
  "catppuccin",
  "dark-light",
  "env_logger",
+ "freedesktop-icons",
  "freedesktop_entry_parser",
  "futures",
  "global-hotkey",
@@ -4945,8 +4988,18 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
- "dlv-list",
+ "dlv-list 0.3.0",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d6a8c22fc714f0c2373e6091bf6f5e9b37b1bc0b1184874b7e0a4e303d318f"
+dependencies = [
+ "dlv-list 0.5.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -6075,7 +6128,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
  "cfg-if",
- "ordered-multimap",
+ "ordered-multimap 0.4.3",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap 0.7.1",
 ]
 
 [[package]]
@@ -7104,6 +7167,15 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -8435,6 +8507,12 @@ name = "xcursor"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xdg-home"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ swift-rs = "1.0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 freedesktop_entry_parser = "1.3.0"
+freedesktop-icons = "0.2.6"
 
 [features]
 tailscale = []

--- a/src/platform/linux/desktop_file.rs
+++ b/src/platform/linux/desktop_file.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use freedesktop_entry_parser::{AttrSelector, parse_entry};
+use freedesktop_icons::lookup;
 
 pub(crate) struct ApplicationDesktopFile {
     pub name: String,
@@ -12,6 +13,17 @@ pub(crate) enum DesktopFileError {
     NoDesktopEntry,
     InvalidFormat,
     HiddenFile,
+}
+
+impl ApplicationDesktopFile {
+    pub(crate) fn resolve_icon(&self) -> Option<PathBuf> {
+        let icon_name = self.icon.as_ref()?;
+
+        lookup(icon_name)
+            .with_cache()
+            .find()
+    }
+
 }
 
 impl TryFrom<&PathBuf> for ApplicationDesktopFile {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -26,7 +26,7 @@ pub fn get_app_data(path: &PathBuf) -> Option<AppData> {
     let icon_url: Option<PathBuf> = file.resolve_icon();
 
     let icon_img = if let Some(icon) = icon_url.clone() {
-        if (icon.to_string_lossy().to_string().ends_with(".svg")) {
+        if (icon.extension().unwrap_or_default().eq("svg")) {
             // TODO: Add support for SVG icons
             Img::list_icon(Icon::AppWindow, None)
         } else {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -23,12 +23,24 @@ pub fn get_app_data(path: &PathBuf) -> Option<AppData> {
         .to_string();
 
     let file = desktop_file::ApplicationDesktopFile::try_from(path).ok()?;
+    let icon_url: Option<PathBuf> = file.resolve_icon();
+
+    let icon_img = if let Some(icon) = icon_url.clone() {
+        if (icon.to_string_lossy().to_string().ends_with(".svg")) {
+            // TODO: Add support for SVG icons
+            Img::list_icon(Icon::AppWindow, None)
+        } else {
+            Img::list_file(icon)
+        }
+    } else {
+        Img::list_icon(Icon::AppWindow, None)
+    };
 
     Some(AppData {
         id: file_name.clone(),
         name: file.name.clone(),
-        icon: Img::list_icon(Icon::AppWindow, None),
-        icon_path: PathBuf::new(),
+        icon: icon_img,
+        icon_path: icon_url.unwrap_or_else(|| PathBuf::new()),
         keywords: file.keywords,
         tag: "Application".to_string(),
     })


### PR DESCRIPTION
This is a small pr that renders .png app icons on linux.

Svg from files doesn't seem to be supported by gpui currently. 
Do you have an idea on how to load these? If not, I'd wait with that until that's doable easily on gpui-side.