### PR TITLE
linux: Use XDG env vars for application search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,6 +4315,7 @@ dependencies = [
  "time",
  "toml 0.8.12",
  "url",
+ "walkdir",
  "whoami",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ cocoa = "0.25.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 freedesktop_entry_parser = "1.3.0"
 freedesktop-icons = "0.2.6"
+walkdir = "2.5.0"
 
 [features]
 tailscale = []

--- a/src/commands/root/list.rs
+++ b/src/commands/root/list.rs
@@ -19,7 +19,7 @@ use crate::{
         list::{nucleo::fuzzy_match, Accessory, Item, ItemBuilder, ListBuilder, ListItem},
         shared::{Icon, Img},
     },
-    platform::get_application_data,
+    platform::{get_applications_folders, get_application_data},
     state::{Action, StateViewBuilder, StateViewContext},
     window::Window,
 };
@@ -84,33 +84,7 @@ impl StateViewBuilder for RootListBuilder {
             .build(
                 |_, _, _cx| {
                     {
-                        let user_dir = PathBuf::from("/Users")
-                            .join(whoami::username())
-                            .join("Applications");
-
-                        #[cfg(target_os = "macos")]
-                        let applications_folders = vec![
-                            PathBuf::from("/Applications"),
-                            PathBuf::from("/Applications/Chromium Apps"),
-                            PathBuf::from("/System/Applications/Utilities"),
-                            PathBuf::from("/System/Applications"),
-                            PathBuf::from("/System/Library/CoreServices/Applications"),
-                            PathBuf::from("/Library/PreferencePanes"),
-                            PathBuf::from("/System/Library/ExtensionKit/Extensions"),
-                            user_dir.clone(),
-                            user_dir.clone().join("Chromium Apps.localized"),
-                            // Not sure about the correct path for PWAs
-                            user_dir.clone().join("Chrome Apps.localized"),
-                            user_dir.clone().join("Brave Apps.localized"),
-                        ];
-                        #[cfg(target_os = "linux")]
-                        let applications_folders = vec![
-                            PathBuf::from("/usr/share/applications"),
-                            PathBuf::from("/usr/local/share/applications"),
-                            PathBuf::from("/home")
-                                .join(whoami::username())
-                                .join(".local/share/applications"),
-                        ];
+                        let applications_folders = get_applications_folders();
 
                         let mut apps = HashMap::<String, Item>::new();
 

--- a/src/commands/root/list.rs
+++ b/src/commands/root/list.rs
@@ -138,8 +138,8 @@ impl StateViewBuilder for RootListBuilder {
                                             Window::close(cx);
                                             let mut command =
                                             std::process::Command::new("gtk-launch");
-                                        command.arg(id.clone());
-                                        let _ = command.spawn();
+                                            command.arg(id.clone());
+                                            let _ = command.spawn();
                                         }
                                     }
                                 },

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -51,6 +51,16 @@ pub fn get_application_data(path: &PathBuf) -> Option<AppData> {
     })
 }
 
+pub fn get_applications_folders() -> Vec<PathBuf> {
+    return vec![
+        PathBuf::from("/usr/share/applications"),
+        PathBuf::from("/usr/local/share/applications"),
+        PathBuf::from("/home")
+            .join(whoami::username())
+            .join(".local/share/applications"),
+    ];
+}
+
 pub fn get_frontmost_application_data() -> Option<AppData> {
     None
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -11,10 +11,12 @@
 
 mod desktop_file;
 
+use walkdir::WalkDir;
+
 use crate::components::shared::{Icon, Img};
 use crate::paths::paths;
 
-use std::fs;
+use std::{fs, env};
 use std::path::PathBuf;
 
 use super::AppData;
@@ -51,14 +53,67 @@ pub fn get_application_data(path: &PathBuf) -> Option<AppData> {
     })
 }
 
+fn get_desktop_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    if let Ok(data_home) = env::var("XDG_DATA_HOME") {
+        let data_home = PathBuf::from(data_home);
+        if data_home.exists() {
+            dirs.push(data_home);
+        }
+    } else {
+        let home_dir = PathBuf::from("/home").join(whoami::username());
+        let share_dir = home_dir.join(PathBuf::from("/.local/share"));
+
+        if share_dir.exists() {
+            dirs.push(share_dir);
+        }
+    }
+
+    if let Ok(xdg_data_dirs) = env::var("XDG_DATA_DIRS") {
+        dirs.extend(
+            xdg_data_dirs
+                .split(":")
+                .map(|s| PathBuf::from(s))
+                .filter(|d| d.exists()),
+        );
+    } else {
+        let usr_local_share = PathBuf::from("/usr/local/share");
+        let usr_share = PathBuf::from("/usr/share");
+
+        if usr_share.exists() {
+            dirs.push(usr_share);
+        }
+
+        if usr_local_share.exists() {
+            dirs.push(usr_local_share);
+        }
+    }
+
+    return dirs;
+}
+
 pub fn get_application_files() -> Vec<PathBuf> {
-    return vec![
-        PathBuf::from("/usr/share/applications"),
-        PathBuf::from("/usr/local/share/applications"),
-        PathBuf::from("/home")
-            .join(whoami::username())
-            .join(".local/share/applications"),
-    ];
+    let dirs = get_desktop_dirs();
+
+    let mut files = Vec::new();
+    for dir in dirs {
+        let walker = WalkDir::new(dir).into_iter();
+        for entry in walker {
+            if let Ok(entry) = entry {
+                if entry
+                    .path()
+                    .extension()
+                    .and_then(|ext| Some(ext == "desktop"))
+                    .unwrap_or(false)
+                {
+                    files.push(entry.path().to_path_buf());
+                }
+            }
+        }
+    }
+
+    return files;
 }
 
 pub fn get_frontmost_application_data() -> Option<AppData> {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -51,7 +51,7 @@ pub fn get_application_data(path: &PathBuf) -> Option<AppData> {
     })
 }
 
-pub fn get_applications_folders() -> Vec<PathBuf> {
+pub fn get_application_files() -> Vec<PathBuf> {
     return vec![
         PathBuf::from("/usr/share/applications"),
         PathBuf::from("/usr/local/share/applications"),

--- a/src/platform/mac.rs
+++ b/src/platform/mac.rs
@@ -63,6 +63,27 @@ pub fn get_application_data(path: &Path) -> Option<AppData> {
     })
 }
 
+pub fn get_applications_folders() -> Vec<PathBuf> {
+    let user_dir = PathBuf::from("/Users")
+        .join(whoami::username())
+        .join("Applications");
+
+    return vec![
+        PathBuf::from("/Applications"),
+        PathBuf::from("/Applications/Chromium Apps"),
+        PathBuf::from("/System/Applications/Utilities"),
+        PathBuf::from("/System/Applications"),
+        PathBuf::from("/System/Library/CoreServices/Applications"),
+        PathBuf::from("/Library/PreferencePanes"),
+        PathBuf::from("/System/Library/ExtensionKit/Extensions"),
+        user_dir.clone(),
+        user_dir.clone().join("Chromium Apps.localized"),
+        // Not sure about the correct path for PWAs
+        user_dir.clone().join("Chrome Apps.localized"),
+        user_dir.clone().join("Brave Apps.localized"),
+    ];
+}
+
 pub fn get_frontmost_application_data() -> Option<AppData> {
     let cache_dir = paths().cache.join("apps");
     if !cache_dir.exists() {

--- a/src/platform/mac.rs
+++ b/src/platform/mac.rs
@@ -63,12 +63,12 @@ pub fn get_application_data(path: &Path) -> Option<AppData> {
     })
 }
 
-pub fn get_applications_folders() -> Vec<PathBuf> {
+pub fn get_application_files() -> Vec<PathBuf> {
     let user_dir = PathBuf::from("/Users")
         .join(whoami::username())
         .join("Applications");
 
-    return vec![
+    let application_folders = vec![
         PathBuf::from("/Applications"),
         PathBuf::from("/Applications/Chromium Apps"),
         PathBuf::from("/System/Applications/Utilities"),
@@ -82,6 +82,21 @@ pub fn get_applications_folders() -> Vec<PathBuf> {
         user_dir.clone().join("Chrome Apps.localized"),
         user_dir.clone().join("Brave Apps.localized"),
     ];
+
+    let files = Vec::new();
+
+    for applications_folder in applications_folders {
+        let dir = applications_folder.read_dir();
+        if dir.is_err() {
+            continue;
+        }
+        for entry in dir.unwrap().flatten() {
+            let path = entry.path();
+            files.push(path);
+        }
+    }
+
+    return files;
 }
 
 pub fn get_frontmost_application_data() -> Option<AppData> {

--- a/src/platform/mac.rs
+++ b/src/platform/mac.rs
@@ -15,7 +15,7 @@ use crate::window::Window;
 use cocoa::appkit::NSPasteboard;
 use gpui::{AsyncWindowContext, WindowContext};
 use std::time::Duration;
-use std::{fs, path::Path};
+use std::{fs, path::{Path, PathBuf}};
 use swift_rs::{swift, Bool, SRObject, SRString};
 
 use super::{AppData, ClipboardWatcher};
@@ -68,7 +68,7 @@ pub fn get_application_files() -> Vec<PathBuf> {
         .join(whoami::username())
         .join("Applications");
 
-    let application_folders = vec![
+    let applications_folders = vec![
         PathBuf::from("/Applications"),
         PathBuf::from("/Applications/Chromium Apps"),
         PathBuf::from("/System/Applications/Utilities"),
@@ -83,7 +83,7 @@ pub fn get_application_files() -> Vec<PathBuf> {
         user_dir.clone().join("Brave Apps.localized"),
     ];
 
-    let files = Vec::new();
+    let mut files = Vec::new();
 
     for applications_folder in applications_folders {
         let dir = applications_folder.read_dir();


### PR DESCRIPTION
The PR uses the environment variables provided by the XDG desktop spec when searching for applications. I used `walkdir` because at least on NixOS, the *.desktop files are nested within the folders.  

Absolutely love the project!