### PR TITLE
Fix missing .clone() on username for Linux target

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -26,7 +26,7 @@ impl Paths {
         #[cfg(target_os = "macos")]
         let user_dir = PathBuf::from("/Users").join(username.clone());
         #[cfg(target_os = "linux")]
-        let user_dir = PathBuf::from("/home").join(username);
+        let user_dir = PathBuf::from("/home").join(username.clone());
         Self {
             #[cfg(target_os = "macos")]
             path_env: format!(


### PR DESCRIPTION
Was trying to compile the latest commit at 5bda8a3c1432ce6fd009ad81e63b71bff1dc0cd7 on Linux and got the following error:

```rust
error[E0382]: borrow of moved value: `username`
  --> src/paths.rs:39:17
   |
25 |         let username = whoami::username();
   |             -------- move occurs because `username` has type `std::string::String`, which does not implement the `Copy` trait
...
29 |         let user_dir = PathBuf::from("/home").join(username);
   |                                                    -------- value moved here
...
39 |                 username
   |                 ^^^^^^^^ value borrowed here after move
   |
   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider cloning the value if the performance cost is acceptable
   |
29 |         let user_dir = PathBuf::from("/home").join(username.clone());
   |                                                            ++++++++
```

There was a `.clone()` used a few lines above for the macOS target, so thought it should be ok to use here too:

https://github.com/MatthiasGrandl/Loungy/blob/5bda8a3c1432ce6fd009ad81e63b71bff1dc0cd7/src/paths.rs#L26-L29